### PR TITLE
Fix caching of queries

### DIFF
--- a/data/test.tt
+++ b/data/test.tt
@@ -13,6 +13,12 @@ class @org.thingpedia.builtin.test
   #[poll_interval=0ms]
   #[doc="generate `size` amount of fake data"];
 
+  query next_sequence(out number: Number)
+  #_[canonical="get sequence number on test"]
+  #_[confirmation="return the next test number"]
+  #_[formatted=[{type="text",text="${number}"}]]
+  #[doc="return the next number in a global sequence; used to test that the queries are invoked the correct number of times; this query is an abuse (it has side effects!), don't copy it in your own devices"];
+
   query dup_data(in req data_in: String #_[prompt="What data do you want to duplicate?"],
                  out data_out: String)
   #_[canonical="duplicate data on test"]
@@ -26,4 +32,3 @@ class @org.thingpedia.builtin.test
   #_[confirmation_remote="consume $data on $__person's Almond"]
   #[doc="consume some data, do nothing"];
 }
-

--- a/lib/apps/exec_wrapper.js
+++ b/lib/apps/exec_wrapper.js
@@ -77,21 +77,32 @@ module.exports = class ExecWrapper extends ExecEnvironment {
         // nothing to do
     }
 
+    _wrapClearCache(asyncIterable) {
+        const self = this;
+        return {
+            async next() {
+                const value = await asyncIterable.next();
+                self.clearGetCache();
+                return value;
+            }
+        };
+    }
+
     invokeTimer(base, interval) {
         this._trigger = new Timer(base, interval);
         this._trigger.start();
-        return this._trigger;
+        return this._wrapClearCache(this._trigger);
     }
     invokeAtTimer(time) {
         this._trigger = new AtTimer(time);
         this._trigger.start();
-        return this._trigger;
+        return this._wrapClearCache(this._trigger);
     }
     invokeMonitor(fnid, params) {
         const fn = this._functions[fnid];
         this._trigger = new TriggerRunner(this, this._acquireFunction(fnid), fn.channel, params);
         this._trigger.start();
-        return this._trigger;
+        return this._wrapClearCache(this._trigger);
     }
 
     _findInCache(fnid, params) {
@@ -104,6 +115,9 @@ module.exports = class ExecWrapper extends ExecEnvironment {
                 return result;
         }
         return null;
+    }
+    clearGetCache() {
+        this._execCache = [];
     }
 
     invokeQuery(fnid, params) {
@@ -120,7 +134,7 @@ module.exports = class ExecWrapper extends ExecEnvironment {
         const function_name = 'get_' + fn.channel;
         const filter = ThingTalk.Ast.BooleanExpression.True;
 
-        return Promise.all(devices.map((d) =>
+        const list = Promise.all(devices.map((d) =>
             safeInvoke(d[function_name](params, filter))
         )).then((results) => {
             // TODO make this streaming
@@ -134,9 +148,12 @@ module.exports = class ExecWrapper extends ExecEnvironment {
                     list.push([outputType, element]);
                 }
             });
-            this._execCache.push([fn.selector.kind, fn.channel, params, list]);
             return list;
         });
+        // cache now, rather than when the query completes, because ThingTalk might
+        // invoke multiple queries in parallel
+        this._execCache.push([fn.selector.kind, fn.channel, params, list]);
+        return list;
     }
 
     readState(stateId) {

--- a/lib/devices/builtins/test.js
+++ b/lib/devices/builtins/test.js
@@ -23,6 +23,12 @@ module.exports = class TestDevice extends Tp.BaseDevice {
         this.name = "Test Device";
         this.description = "Test Device, does nothing but generate fake data";
         this.isTransient = true;
+
+        this._sequenceNumber = 0;
+    }
+
+    get_next_sequence() {
+        return [{ number: this._sequenceNumber ++ }];
     }
 
     get_get_data({ size, count }) {


### PR DESCRIPTION
Wrap each timer and monitor to clear the cache every time they
trigger.

Also add tests for this behavior, ensuring that non-deterministic queries
are called the right number of times.