### PR TITLE
PermissionManager: expose metadata

### DIFF
--- a/lib/permissions/permission_manager.js
+++ b/lib/permissions/permission_manager.js
@@ -89,7 +89,8 @@ module.exports = class PermissionManager {
                 uniqueId: uniqueId,
                 rule: rule,
                 code: rule.prettyprint(),
-                description: extra.$description
+                description: extra.$description,
+                metadata: extra
             });
         }
 


### PR DESCRIPTION
We can use the metadata to eg. store who created the permission in a multi-user scenario