### PR TITLE
messaging/device_manager: add support for managing more than one device at once

### DIFF
--- a/lib/devices/builtins/matrix/index.js
+++ b/lib/devices/builtins/matrix/index.js
@@ -10,16 +10,12 @@
 "use strict";
 
 global.Olm = require('olm');
-const Q = require('q');
 const Tp = require('thingpedia');
 const Matrix = require("matrix-js-sdk");
 
 const sql = require('../../../db/sqlite');
 const SqliteStore = require('./sqlitestore');
 const CryptoSqliteStore = require('./cryptosqlitestore');
-
-const HOMESERVER_URL = process.env.MATRIX_HOMESERVER_URL || 'https://matrix.org';
-const IDENTITY_SERVER_URL = process.env.MATRIX_IDENTITY_SERVER_URL || 'https://matrix.org';
 
 const MatrixMessaging = require('./matrix_messaging');
 
@@ -74,32 +70,24 @@ class DeviceStateStorage {
     }
 }
 
-function makeMatrixClient(userId, deviceId, platform, storage, accessToken) {
-    let db = sql.db(platform.getSqliteDB(), platform.getSqliteKey());
-    let ownerId = userId + '/' + deviceId;
+async function makeMatrixClient(userId, deviceId, platform, storage, accessToken, options) {
+    const db = sql.db(platform.getSqliteDB(), platform.getSqliteKey());
+    const ownerId = userId + '/' + deviceId;
 
-    let store = new SqliteStore({ userId: ownerId, db: db });
-    return Q(store.startup()).then(() => {
-        let matrixClient = Matrix.createClient({
-            baseUrl: HOMESERVER_URL,
-            idBaseUrl: IDENTITY_SERVER_URL,
-            store: store,
-            sessionStore: new Matrix.WebStorageSessionStore(storage),
-            cryptoStore: new CryptoSqliteStore(db, ownerId),
-            userId: userId,
-            deviceId: deviceId,
-            accessToken: accessToken
-        });
-        matrixClient.initCrypto();
-        return matrixClient;
+    const store = new SqliteStore({ userId: ownerId, db: db });
+    await store.startup();
+    const matrixClient = Matrix.createClient({
+        baseUrl: options.homeServerURL,
+        idBaseUrl: options.identityServerURL,
+        store: store,
+        sessionStore: new Matrix.WebStorageSessionStore(storage),
+        cryptoStore: new CryptoSqliteStore(db, ownerId),
+        userId: userId,
+        deviceId: deviceId,
+        accessToken: accessToken
     });
-}
-
-function makeRequest(path, data) {
-    return Tp.Helpers.Http.post(HOMESERVER_URL + path, JSON.stringify(data), {
-        ignoreErrors: true,
-        dataContentType: 'application/json',
-    }).then((response) => JSON.parse(response));
+    matrixClient.initCrypto();
+    return matrixClient;
 }
 
 function toIdentity(medium, address) {
@@ -109,66 +97,66 @@ function toIdentity(medium, address) {
         return medium + ':' + address;
 }
 
-function configureFromAlmond(engine, delegate) {
+async function configureFromAlmond(engine, delegate, options) {
     // NOTE: if you change the sentences used here, make sure to change tests/create_test_users.js
     // in platform-cmdline
 
-    return Q(delegate.requestCode(engine._("Insert your email address or phone number:"))).then((identity) => {
-        let identityType = 'phone';
-        if (identity.indexOf('@') > 0)
-            identityType = 'email';
-        else if (!identity.startsWith('+') && !identity.startsWith('1'))
-            identity = '+1' + identity.replace(/^[0-9]/g, '');
-        let medium, address;
-        if (identityType === 'phone') {
-            medium = 'msisdn';
-            address = identity.replace('+', '');
-        } else {
-            medium = identityType;
-            address = identity;
-        }
+    let identity = await delegate.requestCode(engine._("Insert your email address or phone number:"));
+    let identityType = 'phone';
+    if (identity.indexOf('@') > 0)
+        identityType = 'email';
+    else if (!identity.startsWith('+') && !identity.startsWith('1'))
+        identity = '+1' + identity.replace(/^[0-9]/g, '');
+    let medium, address;
+    if (identityType === 'phone') {
+        medium = 'msisdn';
+        address = identity.replace('+', '');
+    } else {
+        medium = identityType;
+        address = identity;
+    }
 
-        return Q(delegate.requestCode(engine._("Insert your password:"), true)).then((password) => {
-                return makeRequest('/_matrix/client/r0/login', {
-                    type: 'm.login.password',
-                    identifier: {
-                        type: 'm.id.thirdparty',
-                        medium,
-                        address
-                    },
-                    password
-                });
-        }).then((response) => {
-            if (response.errcode)
-                throw new Error(engine._("Authentication failed: %s").format(response.error));
+    const password = await delegate.requestCode(engine._("Insert your password:"), true);
 
-            return Tp.Helpers.Http.get('/_matrix/client/r0/account/3pid?access_token=' + encodeURIComponent(response.access_token)).then((threepidres) => {
-                threepidres = JSON.parse(threepidres);
+    const response = JSON.parse(await Tp.Helpers.Http.post(options.homeServerURL + '/_matrix/client/r0/login', JSON.stringify({
+        type: 'm.login.password',
+        identifier: {
+            type: 'm.id.thirdparty',
+            medium,
+            address
+        },
+        password
+    }), {
+        ignoreErrors: true,
+        dataContentType: 'application/json',
+    }));
+    if (response.errcode)
+        throw new Error(engine._("Authentication failed: %s").format(response.error));
 
-                return engine.devices.loadOneDevice({ kind: 'org.thingpedia.builtin.matrix',
-                                                      identities: threepidres.map((threepid) => toIdentity(threepid.medium, threepid.address)),
-                                                      userId: response.user_id,
-                                                      accessToken: response.access_token,
-                                                      refreshToken: response.refresh_token,
-                                                      homeServer: response.home_server,
-                                                      deviceId: response.device_id,
-                                                      storage: {} }, true);
-            }).catch((e) => {
-                // ignore errors in this call
+    try {
+        const threepidres = JSON.parse(await Tp.Helpers.Http.get(options.homeServerURL + '/_matrix/client/r0/account/3pid?access_token=' + encodeURIComponent(response.access_token)));
 
-                return engine.devices.loadOneDevice({ kind: 'org.thingpedia.builtin.matrix',
-                                                      identities: [identityType + ':' + identity],
-                                                      userId: response.user_id,
-                                                      accessToken: response.access_token,
-                                                      refreshToken: response.refresh_token,
-                                                      homeServer: response.home_server,
-                                                      deviceId: response.device_id,
-                                                      storage: {} }, true);
-            });
-        }).then((device) => {
-            delegate.configDone();
-        });
-    });
+        await engine.devices.loadOneDevice({ kind: 'org.thingpedia.builtin.matrix',
+                                             identities: threepidres.map((threepid) => toIdentity(threepid.medium, threepid.address)),
+                                             userId: response.user_id,
+                                             accessToken: response.access_token,
+                                             refreshToken: response.refresh_token,
+                                             homeServer: response.home_server,
+                                             deviceId: response.device_id,
+                                             storage: {} }, true);
+    } catch(e) {
+        // ignore errors in this call
+
+        await engine.devices.loadOneDevice({ kind: 'org.thingpedia.builtin.matrix',
+                                             identities: [identityType + ':' + identity],
+                                             userId: response.user_id,
+                                             accessToken: response.access_token,
+                                             refreshToken: response.refresh_token,
+                                             homeServer: response.home_server,
+                                             deviceId: response.device_id,
+                                             storage: {} }, true);
+    }
+    delegate.configDone();
 }
 
 module.exports = class MatrixDevice extends Tp.BaseDevice {
@@ -176,7 +164,10 @@ module.exports = class MatrixDevice extends Tp.BaseDevice {
         throw new Error('Not implemented yet');
     }
     static configureFromAlmond(engine, delegate) {
-        return configureFromAlmond(engine, delegate);
+        return configureFromAlmond(engine, delegate, {
+            homeServerURL: process.env.MATRIX_HOMESERVER_URL || 'https://matrix.org',
+            identityServerURL: process.env.MATRIX_IDENTITY_SERVER_URL || 'https://matrix.org'
+        });
     }
 
     constructor(engine, state) {
@@ -221,14 +212,18 @@ module.exports = class MatrixDevice extends Tp.BaseDevice {
     refMatrixClient() {
         if (this._matrixClientCount > 0) {
             this._matrixClientCount++;
-            return Q(this._matrixClient);
+            return Promise.resolve(this._matrixClient);
         }
 
         this._matrixClientCount ++;
         if (this._matrixClient) // still alive because of the 5s timeout after the last unref
             return this._matrixClient;
 
-        return this._matrixClient = makeMatrixClient(this.userId, this.state.deviceId, this.engine.platform, this._matrixStorage, this.accessToken);
+        return this._matrixClient = makeMatrixClient(this.userId, this.state.deviceId, this.engine.platform,
+            this._matrixStorage, this.accessToken, {
+            homeServerURL: process.env.MATRIX_HOMESERVER_URL || 'https://matrix.org',
+            identityServerURL: process.env.MATRIX_IDENTITY_SERVER_URL || 'https://matrix.org'
+        });
     }
 
     unrefMatrixClient() {
@@ -238,7 +233,7 @@ module.exports = class MatrixDevice extends Tp.BaseDevice {
 
         setTimeout(() => {
             if (this._matrixClientCount === 0) {
-                Q(this._matrixClient).then((client) => client.stopClient());
+                Promise.resolve(this._matrixClient).then((client) => client.stopClient());
                 this._matrixClient = null;
             }
         }, 5000);

--- a/lib/devices/builtins/matrix/matrix_messaging.js
+++ b/lib/devices/builtins/matrix/matrix_messaging.js
@@ -30,7 +30,7 @@ function arrayEqual(a, b) {
 
 class MatrixUser {
     constructor(o) {
-        this.account = o.user_id;
+        this.account = 'matrix-account:' + o.user_id;
         this.name = o.display_name;
         this.thumbnail = o.avatar_url;
     }
@@ -38,19 +38,21 @@ class MatrixUser {
 
 class Feed extends Tp.Messaging.Feed {
     constructor(messaging, room) {
-        super(room.roomId);
+        super('matrix:' + room.roomId);
 
+        this._roomId = room.roomId;
         this._messaging = messaging;
         this._device = messaging._device;
     }
 
     getMembers() {
         let members = [];
-        let room = this._messaging.client.getRoom(this.feedId);
+        let room = this._messaging.client.getRoom(this._roomId);
         for (let state of ['join', 'invite']) {
             for (let member of room.getMembersWithMembership(state))
-                members.push(member.userId);
+                members.push('matrix-account:' + member.userId);
         }
+        members.sort();
         return members;
     }
 
@@ -62,7 +64,7 @@ class Feed extends Tp.Messaging.Feed {
     _doOpen() {
         return this._device.refMatrixClient().then((client) => {
             this._client = client;
-            this._room = this._client.getRoom(this.feedId);
+            this._room = this._client.getRoom(this._roomId);
         });
     }
 
@@ -74,7 +76,7 @@ class Feed extends Tp.Messaging.Feed {
     }
 
     sendText(text) {
-        return Q(this._client.sendTextMessage(this.feedId, text));
+        return Q(this._client.sendTextMessage(this._roomId, text));
     }
 
     _getUploadable(url) {
@@ -118,12 +120,12 @@ class Feed extends Tp.Messaging.Feed {
 
     sendPicture(url) {
         return this._getMxcUrl(url).then((url) => {
-            return this._client.sendImageMessage(this.feedId, url, {}, 'image');
+            return this._client.sendImageMessage(this._roomId, url, {}, 'image');
         });
     }
 
     sendItem(item) {
-        return this._client.sendEvent(this.feedId, THINGPEDIA_EVENT_TYPE, item);
+        return this._client.sendEvent(this._roomId, THINGPEDIA_EVENT_TYPE, item);
     }
 }
 
@@ -176,7 +178,7 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
 
         let obj = {
             serverTimestamp: event.getTs(),
-            sender: event.getSender(),
+            sender: 'matrix-account:' + event.getSender(),
             msgId: event.getId(),
         };
 
@@ -216,14 +218,14 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
         let feed = this._feeds.get(room);
         if (feed)
             feed._newMessage(direction, obj);
-        this.emit(direction, room.roomId, obj, event);
+        this.emit(direction, 'matrix:' + room.roomId, obj, event);
 
         if (direction === 'incoming-message' && sendReceipt)
             this.client.sendReadReceipt(event);
     }
 
     get account() {
-        return this._device.userId;
+        return 'matrix-account:' + this._device.userId;
     }
 
     get type() {
@@ -234,11 +236,9 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
         return this._device.identities;
     }
 
-    feedClosed(identifier) {
-        // nothing to do here
-    }
-
     getFeed(feedId) {
+        if (feedId.startsWith('matrix:'))
+            feedId = feedId.substring('matrix:'.length);
         return this._getFeedForRoom(this.client.getRoom(feedId), feedId);
     }
 
@@ -280,6 +280,8 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
     }
 
     getUserByAccount(account) {
+        if (account.startsWith('matrix-account:'))
+            account = account.substring('matrix-account:'.length);
         return Q(new MatrixUser(this.client.getUser(account) || new Matrix.User(account)));
     }
 
@@ -287,8 +289,6 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
         if (this._feeds.has(room))
             return this._feeds.get(room);
 
-        if (room === null) // HACK
-            return Q.delay(100).then(() => this._getFeedForRoom(this.client.getRoom(feedId), feedId));
         let feed = new Feed(this, room);
         this._feeds.set(room, feed);
         return feed;
@@ -299,8 +299,13 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
     }
 
     createFeed() {
-        return Q(this.client.createRoom({ visibility: 'private', preset: 'private_chat' })).then((obj) => {
+        return Q(this.client.createRoom({ visibility: 'private', preset: 'private_chat' })).then(async (obj) => {
             let room = this.client.getRoom(obj.room_id);
+            if (room === null) {
+                // HACK
+                await Q.delay(100);
+                room = this.client.getRoom(obj.room_id);
+            }
             let feed = this._getFeedForRoom(room, obj.room_id);
 
             // enable end-to-end crypto once i figure out the configuration...
@@ -324,6 +329,9 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
     }
 
     getFeedByAlias(aliasId) {
+        if (aliasId.startsWith('matrix:'))
+            aliasId = aliasId.substring('matrix:'.length);
+    
         if (aliasId.startsWith('!'))
             return Q(this.getFeed(aliasId));
 
@@ -338,7 +346,7 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
     }
 
     _findExistingFeedWithContact(contacts) {
-        let searchKey = [this.account].concat(contacts);
+        let searchKey = [this._device.userId].concat(contacts);
         searchKey.sort();
 
         for (let room of this.client.getRooms()) {
@@ -387,10 +395,12 @@ module.exports = class MatrixMessaging extends Tp.Messaging {
             address = address.replace('+', '');
         }
         if (medium === 'matrix-account')
-            return this.client.getUser(address);
+            return Q(this.client.getUser(address)).then((user) => user ? 'matrix-account:' + user.user_id : null);
+        if (medium !== 'msisdn' && medium !== 'email')
+            return Q(null);
 
         return Q(this.client.lookupThreePid(medium, address)).then((response) => {
-            return response.mxid;
+            return response.mxid ? 'matrix-account:' + response.mxid : null;
         });
     }
 

--- a/lib/messaging/communication_manager.js
+++ b/lib/messaging/communication_manager.js
@@ -19,6 +19,9 @@ const RemoteProgramExecutor = require('./remote_program_executor');
 
 const CURRENT_VERSION = 3;
 
+const MESSAGING_ACCOUNT_REGEX = /^([A-Za-z.0-9]+)-account:/;
+const VALID_IDENTITY_REGEX = /^(?:email|phone|omlet|almond|[A-Za-z.0-9]+-account):/;
+
 const Message = {
     INSTALL: 'i',
     ABORT: 'a',
@@ -383,21 +386,10 @@ module.exports = class CommunicationManager {
     }
 
     _normalizePrincipal(principal) {
-        const userprefix = this._messaging.type + '-account:';
-        const roomprefix = this._messaging.type + '-room:';
-        if (Array.isArray(principal)) {
-            principal = principal.map((p) => {
-                p = String(p);
-                if (p.startsWith(userprefix))
-                    p = p.substr(userprefix.length);
-                return p;
-            });
-        } else {
+        if (!Array.isArray(principal)) {
             principal = String(principal);
-            if (principal.startsWith(userprefix))
-                principal = [principal.substr(userprefix.length)];
-            else if (principal.startsWith(roomprefix))
-                principal = principal.substr(roomprefix.length);
+            if (MESSAGING_ACCOUNT_REGEX.test(principal))
+                principal = [principal];
         }
 
         return principal;
@@ -412,12 +404,12 @@ module.exports = class CommunicationManager {
     _verifyIdentity(principal, identity) {
         if (!identity)
             return Promise.reject(throwCode('EINVAL', 'Invalid identity'));
-        if (!identity.startsWith('phone:') && !identity.startsWith('email:') && !identity.startsWith('omlet:') && !identity.startsWith('matrix-account:'))
+        if (!VALID_IDENTITY_REGEX.test(identity))
             return Promise.reject(throwCode('EINVAL', 'Invalid identity ' + identity));
         return this._messaging.getAccountForIdentity(identity).then((account) => {
             if (!account)
                 throw throwCode('EINVAL', 'Invalid identity ' + identity);
-            if (this._messaging.type + '-account:' + account !== principal)
+            if (account !== principal)
                 throw throwCode('EPERM', 'Identity does not match principal');
         });
     }
@@ -436,8 +428,6 @@ module.exports = class CommunicationManager {
             let identity = parsed.id;
             let code = parsed.c;
 
-            let feedPrincipal = this._messaging.type + '-room:' + feedId;
-            let userPrincipal = this._messaging.type + '-account:' + message.sender;
             this._getSharedProgramState(uniqueId, true);
             let program;
             try {
@@ -446,17 +436,17 @@ module.exports = class CommunicationManager {
                 // we will show a confirmation string to the user and store it in the app database,
                 // so always fetch metadata in addition to type information
                 program = await ThingTalk.Grammar.parseAndTypecheck(code, this._schemaRetriever, true);
-                await this._verifyIdentity(userPrincipal, identity);
+                await this._verifyIdentity(message.sender, identity);
             } catch(error) {
-                await this._sendInstallError(feedPrincipal, uniqueId, error);
+                await this._sendInstallError(feedId, uniqueId, error);
                 return;
             }
 
             // join the program
-            await this._sendJoinProgram(feedPrincipal, uniqueId);
+            await this._sendJoinProgram(feedId, uniqueId);
 
             try {
-                await this._executor.execute(userPrincipal, identity, program, uniqueId).then(() => true);
+                await this._executor.execute(message.sender, identity, program, uniqueId).then(() => true);
             } catch(error) {
                 this._subscriptions.delete(uniqueId);
 
@@ -464,7 +454,7 @@ module.exports = class CommunicationManager {
                     console.error(error);
                 if (!error.code && error instanceof TypeError)
                     error.code = 'EINVAL';
-                await this._sendInstallError(feedPrincipal, uniqueId, error);
+                await this._sendInstallError(feedId, uniqueId, error);
             }
         } catch(e) {
             console.error(e);

--- a/lib/messaging/device_manager.js
+++ b/lib/messaging/device_manager.js
@@ -9,11 +9,49 @@
 // See COPYING for details
 "use strict";
 
+const events = require('events');
 const Tp = require('thingpedia');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 
 const DeviceView = require('../devices/device_view');
+
+const MESSAGING_ACCOUNT_REGEX = /^([A-Za-z.0-9]+)-account:/;
+
+class VirtualFeed extends Tp.Messaging.Feed {
+    constructor(subfeeds) {
+        const id = 'virtual:[' + subfeeds.map((f) => encodeURIComponent(f.feedId)).join(',') + ']';
+        super(id);
+
+        this._subfeeds = subfeeds;
+    }
+
+    getMembers() {
+        const members = [];
+        for (let f of this._subfeeds)
+            members.push(...f.getMembers());
+        return members;
+    }
+
+    _doOpen() {
+        return Promise.all(this._subfeeds.map((f) => f.open()));
+    }
+    _doClose() {
+        return Promise.all(this._subfeeds.map((f) => f.close()));
+    }
+
+    sendText(text) {
+        return Promise.all(this._subfeeds.map((f) => f.sendText(text)));
+    }
+
+    sendItem(item) {
+        return Promise.all(this._subfeeds.map((f) => f.sendItem(item)));
+    }
+
+    sendPicture(url) {
+        return Promise.all(this._subfeeds.map((f) => f.sendPicture(url)));
+    }
+}
 
 // This module observes the addition and removal of messaging devices,
 // and controls the lifetime of additional modules that depend on
@@ -23,11 +61,11 @@ const DeviceView = require('../devices/device_view');
 // based on whatever is the current device
 // (which fails with Error('Device Not Available') if there is no
 // configured messaging device
-module.exports = class MessagingDeviceManager extends Tp.Messaging {
+module.exports = class MessagingDeviceManager extends events.EventEmitter {
     constructor(platform, devices) {
         super();
-        this._messagingDevice = null;
-        this._messagingIface = platform.getCapability('messaging');
+        this._platformMessaging = platform.getCapability('messaging');
+        this._messagingIfaces = [];
 
         this._incomingMessageListener = this._onIncomingMessage.bind(this);
         this._outgoingMessageListener = this._onOutgoingMessage.bind(this);
@@ -36,86 +74,153 @@ module.exports = class MessagingDeviceManager extends Tp.Messaging {
         this._feedChangedListener = this._onFeedChanged.bind(this);
 
         // @messaging
-        if (this._messagingIface === null) {
-            var sel = Ast.Selector.Device('messaging', null, null);
-            this._view = new DeviceView(devices, sel);
-        } else {
-            this._view = null;
-        }
-    }
-
-    get device() {
-        return this._messagingDevice;
-    }
-
-    get type() {
-        if (this._messagingDevice)
-            return this._messagingDevice.kind.substring('org.thingpedia.builtin.'.length);
-        else if (this._messagingIface)
-            return this._messagingIface.type;
-        else
-            return null;
+        var sel = Ast.Selector.Device('messaging', null, null);
+        this._view = new DeviceView(devices, sel);
     }
 
     get isAvailable() {
-        return this._messagingIface !== null;
+        return this._messagingIfaces.length > 0;
     }
 
-    get account() {
+    isSelf(account) {
+        for (let iface of this._messagingIfaces) {
+            if (iface.account === account)
+                return true;
+        }
+        return false;
+    }
+
+    getSelf(sendTo) {
         this._checkAvailable();
-        return this._messagingIface.account;
+
+        if (!sendTo)
+            return this._messagingIfaces[0].account;
+
+        if (Array.isArray(sendTo)) {
+            const match = MESSAGING_ACCOUNT_REGEX.exec(sendTo[0]);
+            if (match === null)
+                throw new Error(`Invalid account format: ${sendTo[0]}`);
+
+            return this._findIface(match[1]).account;
+        } else {
+            sendTo = String(sendTo);
+            const match = MESSAGING_ACCOUNT_REGEX.exec(sendTo);
+            if (match !== null) {
+                return this._findIface(match[1]).account;
+            } else {
+                const colon = sendTo.indexOf(':');
+                const type = sendTo.substring(0, colon);
+                return this._findIface(type).account;
+            }
+        }
     }
 
     getIdentities() {
-        this._checkAvailable();
-        return this._messagingIface.getIdentities();
+        const identities = [];
+        for (let iface of this._messagingIfaces)
+            identities.push(...iface.getIdentities());
+        return identities;
     }
 
     _checkAvailable() {
-        if (this._messagingIface === null)
-            throw new Error('Device Not Available');
+        if (this._messagingIfaces.length === 0)
+            throw new Error('Messaging Not Available');
+    }
+
+    _findIface(type) {
+        for (let iface of this._messagingIfaces) {
+            if (iface.type === type)
+                return iface;
+        }
+        throw new Error(`Invalid messaging type ${type}`);
     }
 
     getUserByAccount(account) {
         this._checkAvailable();
-        return this._messagingIface.getUserByAccount(account);
-    }
 
-    getBlobDownloadLink(blobHash) {
-        this._checkAvailable();
-        return this._messagingIface.getBlobDownloadLink(blobHash);
+        const match = MESSAGING_ACCOUNT_REGEX.exec(account);
+        if (match === null)
+            throw new Error(`Invalid account format: ${account}`);
+
+        return this._findIface(match[1]).getUserByAccount(account);
     }
 
     getFeedList() {
-        if (this._messagingIface === null)
-            return Promise.resolve([]);
-        else
-            return this._messagingIface.getFeedList();
+        return Promise.all(this._messagingIfaces.map((iface) => {
+            return iface.getFeedList();
+        })).then((lists) => {
+            // flatten the array of arrays
+            return [].concat(...lists);
+        });
     }
 
     getFeed(feedId) {
         this._checkAvailable();
-        return this._messagingIface.getFeed(feedId);
+
+        if (feedId.startsWith('virtual:')) {
+            const ids = feedId.substring('virtual:'.length).split(',').map((id) => decodeURIComponent(id));
+            return new VirtualFeed(ids.map((id) => this.getFeed(id)));
+        } else {
+            const colon = feedId.indexOf(':');
+            const type = feedId.substring(0, colon);
+            return this._findIface(type).getFeed(feedId);
+        }
     }
 
     getFeedByAlias(aliasId) {
         this._checkAvailable();
-        return this._messagingIface.getFeedByAlias(aliasId);
+
+        const colon = aliasId.indexOf(':');
+        const type = aliasId.substring(0, colon);
+        return this._findIface(type).getFeedByAlias(aliasId);
     }
 
-    getFeedWithContact(contactId) {
+    getFeedWithContact(contactIds) {
         this._checkAvailable();
-        return this._messagingIface.getFeedWithContact(contactId);
+
+        if (!Array.isArray(contactIds))
+            contactIds = [contactIds];
+
+        let types = {};
+        for (let contactId of contactIds) {
+            const match = MESSAGING_ACCOUNT_REGEX.exec(contactId);
+            if (match === null)
+                throw new Error(`Invalid account format: ${contactId}`);
+            if (match[1] in types) {
+                types[match[1]].contactIds.push(contactId);
+            } else {
+                types[match[1]] = {
+                    iface: this._findIface(match[1]),
+                    contactIds: [contactId]
+                };
+            }
+        }
+        return Promise.all(Object.values(types).map(({iface, contactIds}) => {
+            return iface.getFeedWithContact(contactIds);
+        })).then((feeds) => {
+            if (feeds.length === 1)
+                return feeds[0];
+            else
+                return new VirtualFeed(feeds);
+        });
     }
 
     searchAccountByName(name) {
-        this._checkAvailable();
-        return this._messagingIface.searchAccountByName(name);
+        return Promise.all(this._messagingIfaces.map((iface) => {
+            return iface.searchAccountByName(name);
+        })).then((lists) => {
+            // flatten the array of arrays
+            return [].concat(...lists);
+        });
     }
 
-    getAccountForIdentity(identity) {
-        this._checkAvailable();
-        return this._messagingIface.getAccountForIdentity(identity);
+    async getAccountForIdentity(identity) {
+        for (let iface of this._messagingIfaces) {
+            const candidate = await iface.getAccountForIdentity(identity);
+            if (candidate !== null)
+                return candidate;
+        }
+        return null;
     }
 
     _onFeedAdded(feed) {
@@ -139,16 +244,14 @@ module.exports = class MessagingDeviceManager extends Tp.Messaging {
     }
 
     _tryAddMessagingDevice(device) {
-        this._messagingDevice = device;
-        var iface = device.queryInterface('messaging');
-        this._messagingIface = iface;
+        const iface = device.queryInterface('messaging');
 
         console.log('Found Messaging Device ' + device.uniqueId);
-        this._initMessagingIface();
+        this._initMessagingIface(iface);
     }
 
-    _initMessagingIface() {
-        const iface = this._messagingIface;
+    _initMessagingIface(iface) {
+        this._messagingIfaces.push(iface);
         return iface.start().then(() => {
             return iface.getFeedList();
         }).then((feeds) => {
@@ -158,83 +261,65 @@ module.exports = class MessagingDeviceManager extends Tp.Messaging {
             iface.on('incoming-message', this._incomingMessageListener);
             iface.on('outgoing-message', this._outgoingMessageListener);
 
-            feeds.forEach(function(feedId) {
+            feeds.forEach((feedId) => {
                 this.emit('feed-added', feedId);
-            }, this);
+            });
         });
     }
 
-    _closeMessagingDevice() {
-        this._messagingIface.removeListener('feed-added', this._feedAddedListener);
-        this._messagingIface.removeListener('feed-removed', this._feedRemovedListener);
-        this._messagingIface.removeListener('feed-changed', this._feedChangedListener);
-        this._messagingIface.removeListener('incoming-message', this._incomingMessageListener);
-        this._messagingIface.removeListener('outgoing-message', this._outgoingMessageListener);
+    _closeMessagingDevice(device, iface) {
+        iface.removeListener('feed-added', this._feedAddedListener);
+        iface.removeListener('feed-removed', this._feedRemovedListener);
+        iface.removeListener('feed-changed', this._feedChangedListener);
+        iface.removeListener('incoming-message', this._incomingMessageListener);
+        iface.removeListener('outgoing-message', this._outgoingMessageListener);
 
-        console.log('Lost Messaging Device ' + this._messagingDevice.uniqueId);
-
-        var iface = this._messagingIface;
+        console.log('Lost Messaging Device ' + device.uniqueId);
+        const index = this._messagingIfaces.indexOf(iface);
+        if (index >= 0)
+            this._messagingIfaces.splice(index, 1);
 
         Promise.resolve(iface.getFeedList()).then((feeds) => {
-            feeds.forEach(function(feedId) {
+            feeds.forEach((feedId) => {
                 this.emit('feed-removed', feedId);
-            }, this);
+            });
         }).then(() => {
             return iface.stop();
         });
     }
 
-    _tryFindMessagingDevice() {
-        var messagingDevices = this._view.values();
-        if (messagingDevices.length === 0)
-            return Promise.resolve();
-        return this._tryAddMessagingDevice(messagingDevices[0]);
-    }
-
     _onDeviceAdded(device) {
-        if (this._messagingDevice !== null)
-            return;
         // wrap into a native promise so we crash if unhandled
         Promise.resolve(this._tryAddMessagingDevice(device));
     }
 
     _onDeviceRemoved(device) {
-        if (this._messagingDevice !== device)
-            return;
-
-        this._closeMessagingDevice();
-        this._messagingIface = null;
-        this._messagingDevice = null;
-        // wrap into a native promise so we crash if unhandled
-        Promise.resolve(this._tryFindMessagingDevice());
+        const iface = device.queryInterface('messaging');
+        this._closeMessagingDevice(device, iface);
     }
 
     async start() {
-        if (this._messagingIface !== null) {
-            this._initMessagingIface();
-        } else {
-            this._deviceAddedListener = this._onDeviceAdded.bind(this);
-            this._deviceRemovedListener = this._onDeviceRemoved.bind(this);
-            this._view.start();
-            this._view.on('object-added', this._deviceAddedListener);
-            this._view.on('object-removed', this._deviceRemovedListener);
+        if (this._platformMessaging !== null)
+            this._initMessagingIface(this._platformMessaging);
 
-            await this._tryFindMessagingDevice();
-        }
+        this._deviceAddedListener = this._onDeviceAdded.bind(this);
+        this._deviceRemovedListener = this._onDeviceRemoved.bind(this);
+        this._view.start();
+        this._view.on('object-added', this._deviceAddedListener);
+        this._view.on('object-removed', this._deviceRemovedListener);
+
+        for (let device of this._view.values())
+            this._tryAddMessagingDevice(device);
     }
 
     async stop() {
-        if (this._view !== null) {
-            this._view.removeListener('object-added', this._deviceAddedListener);
-            this._view.removeListener('object-removed', this._deviceRemovedListener);
-            this._deviceAddedListener = null;
-            this._deviceRemovedListener = null;
+        this._view.removeListener('object-added', this._deviceAddedListener);
+        this._view.removeListener('object-removed', this._deviceRemovedListener);
+        this._deviceAddedListener = null;
+        this._deviceRemovedListener = null;
 
-            this._view.stop();
-        }
+        this._view.stop();
 
-        if (this._messagingIface)
-            await this._messagingIface.stop();
+        await Promise.all(this._messagingIfaces.map((iface) => iface.stop()));
     }
 };
-module.exports.prototype.$rpcMethods = ['get isAvailable', 'get account', 'getUserByAccount'];

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,7 @@ const THINGPEDIA_URL = 'https://almond-dev.stanford.edu/thingpedia';
 
 async function runTests(engine, limitTo) {
     try {
-        for (let x of ['devices', 'apps', 'http_client', 'util', 'builtins', 'permissions', 'remote']) {
+        for (let x of ['devices', 'apps', 'http_client', 'util', 'builtins', 'permissions', 'remote', 'messaging']) {
             if (limitTo !== undefined && x !== limitTo)
                 continue;
             console.log(`Running ${x} tests`);

--- a/test/test_messaging.js
+++ b/test/test_messaging.js
@@ -1,0 +1,226 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+
+const TEST_HOMESERVER = 'camembert.stanford.edu';
+
+process.env.MATRIX_IDENTITY_SERVER_URL = `http://${TEST_HOMESERVER}:8090`;
+process.env.MATRIX_HOMESERVER_URL = `http://${TEST_HOMESERVER}:8008`;
+
+function delay(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+async function testMockMessaging(messaging) {
+    assert(messaging.isSelf('mock-account:user1'));
+    assert(!messaging.isSelf('mock-account:user2'));
+    assert(!messaging.isSelf('invalid:user1'));
+    assert(!messaging.isSelf('user1'));
+
+    assert.strictEqual(messaging.getSelf(), 'mock-account:user1');
+    assert.strictEqual(messaging.getSelf('mock-account:user2'), 'mock-account:user1');
+
+    assert.throws(() => messaging.getSelf('other-account:user2'), /^Error: Invalid messaging type other$/g);
+
+    assert.deepStrictEqual(messaging.getIdentities(), ['phone:+1555123456', 'email:bob@example.com']);
+}
+
+async function testLoginAsMatrixUser(engine) {
+    let resolve_, reject_;
+    const promise = new Promise((resolve, reject) => {
+        resolve_ = resolve;
+        reject_ = reject;
+    });
+    const delegate = {
+        reply(msg) {
+            console.log('>> ' + msg);
+        },
+        confirm(question) {
+            console.log('>? ' + question);
+            return Promise.resolve(true);
+        },
+        configDone() {
+            resolve_();
+        },
+        configFailed(error) {
+            reject_(error);
+        },
+        requestCode(question) {
+            console.log('>= ' + question);
+
+            switch (question) {
+            case "Insert your email address or phone number:":
+                return Promise.resolve(`testuser1@${TEST_HOMESERVER}`);
+            case "Insert your password:":
+                return Promise.resolve(`testuser1`);
+            default:
+                throw new Error('Unexpected question');
+            }
+        }
+    };
+
+    const factory = await engine.devices.factory.getFactory('org.thingpedia.builtin.matrix');
+    await factory.configureFromAlmond(engine, delegate);
+    // wait a for full sync
+    await delay(10000);
+    await promise;
+}
+
+async function testMatrix(engine) {
+    const device = engine.devices.getDevice(`org.thingpedia.builtin.matrix-@testuser1:${TEST_HOMESERVER}`);
+
+    assert(device);
+    assert.deepStrictEqual(device.userId, `@testuser1:${TEST_HOMESERVER}`);
+    assert.deepStrictEqual(device.identities, [
+        `email:testuser1@${TEST_HOMESERVER}`,
+        `matrix-account:@testuser1:${TEST_HOMESERVER}`
+    ]);
+
+    const messaging = device.queryInterface('messaging');
+    assert(messaging);
+
+    assert.deepStrictEqual(messaging.type, 'matrix');
+    assert.deepStrictEqual(messaging.account, `matrix-account:@testuser1:${TEST_HOMESERVER}`);
+}
+
+async function testMessagingWithMatrix(engine) {
+    const messaging = engine.messaging;
+
+    assert(messaging.isSelf('mock-account:user1'));
+    assert(messaging.isSelf(`matrix-account:@testuser1:${TEST_HOMESERVER}`));
+    assert(!messaging.isSelf('mock-account:user2'));
+    assert(!messaging.isSelf('invalid:user1'));
+    assert(!messaging.isSelf('user1'));
+
+    assert.strictEqual(messaging.getSelf(), 'mock-account:user1');
+    assert.strictEqual(messaging.getSelf('mock-account:user2'), 'mock-account:user1');
+    assert.strictEqual(messaging.getSelf(`matrix-account:@testuser2:${TEST_HOMESERVER}`), `matrix-account:@testuser1:${TEST_HOMESERVER}`);
+    assert.strictEqual(messaging.getSelf(`matrix-account:@gcampax@matrix.org`), `matrix-account:@testuser1:${TEST_HOMESERVER}`);
+    assert.strictEqual(messaging.getSelf([`matrix-account:@gcampax@matrix.org`, `matrix-account:@testuser2:${TEST_HOMESERVER}`]),
+        `matrix-account:@testuser1:${TEST_HOMESERVER}`);
+
+    assert.deepStrictEqual(messaging.getIdentities(), [
+        'phone:+1555123456',
+        'email:bob@example.com',
+        `email:testuser1@${TEST_HOMESERVER}`,
+        `matrix-account:@testuser1:${TEST_HOMESERVER}`
+    ]);
+
+    let foundMock = false, foundMatrix = false;
+    for (let room of await messaging.getFeedList()) {
+        if (room.feedId.startsWith('mock:')) {
+            assert(room.feedId === 'mock:feed1' || room.feedId === 'mock:feed2');
+            foundMock = true;
+        } else if (room.feedId.startsWith('matrix:')) {
+            assert(room.feedId.endsWith(`:${TEST_HOMESERVER}`));
+            foundMatrix = true;
+
+            //console.log('room ' + room.feedId);
+            //console.log(room.getMembers());
+        } else {
+            assert.fail(`unexpected feed ${room.feedId}`);
+        }
+    }
+    assert(foundMock && foundMatrix);
+
+    const feed1 = messaging.getFeed('matrix:!EmyZpdhYPpXqnQugAk:camembert.stanford.edu');
+    assert(feed1);
+    // an object, not a promise (thenable)
+    assert.strictEqual(typeof feed1.then, 'undefined');
+    assert.deepStrictEqual(feed1.getMembers(), [
+        'matrix-account:@testuser1:camembert.stanford.edu',
+        'matrix-account:@testuser2:camembert.stanford.edu'
+    ]);
+    assert(messaging.getFeed('mock:feed1'));
+    assert(messaging.getFeed('mock:feed2'));
+
+    const feed2 = await messaging.getFeedByAlias('matrix:!EmyZpdhYPpXqnQugAk:camembert.stanford.edu');
+    assert.strictEqual(feed2, feed1);
+
+    const mockFeed1 = await messaging.getFeedWithContact('mock-account:user2');
+    assert.strictEqual(mockFeed1.feedId, 'mock:feed1');
+
+    const matrixFeed1 = await messaging.getFeedWithContact(['matrix-account:@testuser2:camembert.stanford.edu']);
+    assert.strictEqual(matrixFeed1.feedId, 'matrix:!EmyZpdhYPpXqnQugAk:camembert.stanford.edu');
+
+    const mixedFeed1 = await messaging.getFeedWithContact([
+        'mock-account:user2',
+        'matrix-account:@testuser2:camembert.stanford.edu'
+    ]);
+    assert.strictEqual(mixedFeed1.feedId, 'virtual:[mock%3Afeed1,matrix%3A!EmyZpdhYPpXqnQugAk%3Acamembert.stanford.edu]');
+    assert.deepStrictEqual(mixedFeed1.getMembers(), [
+        'mock-account:user1',
+        'mock-account:user2',
+        'matrix-account:@testuser1:camembert.stanford.edu',
+        'matrix-account:@testuser2:camembert.stanford.edu'
+    ]);
+
+    const sentOnMock = new Promise((resolve, reject) => {
+        engine.platform.getCapability('messaging').once('outgoing-message', (feedId, msg) => {
+            try {
+                assert.strictEqual(feedId, 'mock:feed1');
+                assert.strictEqual(msg.sender, 'mock-account:user1');
+                assert.strictEqual(msg.type, 'text');
+                assert.strictEqual(msg.text, 'test message');
+                resolve();
+            } catch(e) {
+                reject(e);
+            }
+        });
+    });
+    const sentOnMatrix = new Promise((resolve, reject) => {
+        const device = engine.devices.getDevice(`org.thingpedia.builtin.matrix-@testuser1:${TEST_HOMESERVER}`);
+
+        device.queryInterface('messaging').once('outgoing-message', (feedId, msg) => {
+            try {
+                assert.strictEqual(feedId, 'matrix:!EmyZpdhYPpXqnQugAk:camembert.stanford.edu');
+                assert.strictEqual(msg.sender, `matrix-account:@testuser1:${TEST_HOMESERVER}`);
+                assert.strictEqual(msg.type, 'text');
+                assert.strictEqual(msg.text, 'test message');
+                resolve();
+            } catch(e) {
+                reject(e);
+            }
+        });
+    });
+
+    await mixedFeed1.open();
+    await mixedFeed1.sendText('test message');
+    await mixedFeed1.close();
+
+    await Promise.all([
+        sentOnMock,
+        sentOnMatrix
+    ]);
+
+
+    assert.strictEqual(await messaging.getAccountForIdentity('phone:+1555123456'), 'mock-account:user1');
+    assert.strictEqual(await messaging.getAccountForIdentity(`email:testuser2@${TEST_HOMESERVER}`), `matrix-account:@testuser2:${TEST_HOMESERVER}`);
+    assert.strictEqual(await messaging.getAccountForIdentity(`email:unknown@example.com`), null);
+
+    assert.deepStrictEqual(await messaging.searchAccountByName('alice'), [await messaging.getUserByAccount('mock-account:user2')]);
+}
+
+module.exports = async function testRemote(engine) {
+    const messaging = engine.messaging;
+    //const remote = engine.remote;
+    assert(messaging.isAvailable);
+
+    await testMockMessaging(messaging);
+
+    await testLoginAsMatrixUser(engine);
+    await testMatrix(engine);
+
+    await testMessagingWithMatrix(engine);
+};

--- a/test/test_remote.js
+++ b/test/test_remote.js
@@ -26,10 +26,12 @@ async function testInstallProgram(engine) {
     await new Promise((resolve, reject) => {
         const uniqueId = uuid.v4();
 
-        messaging.on('incoming-message', (msg) => reject(new Error(`Unexpected message from ${msg.sender}`)));
+        messaging.on('incoming-message', (feedId, msg) => {
+            reject(new Error(`Unexpected message from ${msg.sender}`));
+        });
         messaging.once('outgoing-message', (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
             assert.deepStrictEqual(msg.json, {
                 v: 3,
@@ -58,8 +60,8 @@ async function testHandleInstallNoPermissionNoAssistant(engine) {
 
         let count = 0;
         const listener = (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             switch (count) {
@@ -91,7 +93,7 @@ async function testHandleInstallNoPermissionNoAssistant(engine) {
         };
         messaging.on('outgoing-message', listener);
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -125,8 +127,8 @@ async function testHandleInstallNoPermission(engine) {
 
         let count = 0;
         const listener = (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             switch (count) {
@@ -158,7 +160,7 @@ async function testHandleInstallNoPermission(engine) {
         };
         messaging.on('outgoing-message', listener);
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -196,8 +198,8 @@ async function testHandleInstallNoPermissionSMT(engine) {
 
         let count = 0;
         const listener = (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             switch (count) {
@@ -229,7 +231,7 @@ async function testHandleInstallNoPermissionSMT(engine) {
         };
         messaging.on('outgoing-message', listener);
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -255,8 +257,8 @@ async function testHandleInstallInvalidIdentity(engine) {
         const uniqueId = uuid.v4();
 
         messaging.once('outgoing-message', (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             assert.deepStrictEqual(msg.json, {
@@ -271,7 +273,7 @@ async function testHandleInstallInvalidIdentity(engine) {
             resolve();
         });
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -295,8 +297,8 @@ async function testHandleInstallTypeError(engine) {
         const uniqueId = uuid.v4();
 
         messaging.once('outgoing-message', (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             assert.deepStrictEqual(msg.json, {
@@ -311,7 +313,7 @@ async function testHandleInstallTypeError(engine) {
             resolve();
         });
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -336,8 +338,8 @@ async function testHandleInstallOk(engine) {
 
         let count = 0;
         const listener = (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             switch (count) {
@@ -373,7 +375,7 @@ async function testHandleInstallOk(engine) {
             }
         });
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -402,8 +404,8 @@ async function testHandleInstallOkPermission(engine) {
 
         let count = 0;
         const listener = (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             switch (count) {
@@ -439,7 +441,7 @@ async function testHandleInstallOkPermission(engine) {
             }
         });
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -460,7 +462,7 @@ async function testHandleInstallOkGet(engine) {
     const prog1 = await ThingTalk.Grammar.parseAndTypecheck(`executor = "mock-account:user1"^^tt:contact :
         now => @org.thingpedia.builtin.test.get_data(size=10byte) => return;`, engine.schemas);
     // pass a fake messaging to we send data to user2 not user1
-    prog1.lowerReturn({ type: 'mock', account: 'user2' });
+    prog1.lowerReturn({ getSelf() { return 'mock-account:user2'; } });
     prog1.principal = null;
 
     const code = prog1.prettyprint(true).trim();
@@ -495,8 +497,8 @@ async function testHandleInstallOkGet(engine) {
 
         let count = 0;
         const listener = (feedId, msg) => {
-            assert.deepStrictEqual(feedId, 'feed1');
-            assert.strictEqual(msg.sender, 'user1');
+            assert.deepStrictEqual(feedId, 'mock:feed1');
+            assert.strictEqual(msg.sender, 'mock-account:user1');
             assert.strictEqual(msg.type, 'app');
 
             switch (count) {
@@ -537,7 +539,7 @@ async function testHandleInstallOkGet(engine) {
         };
         messaging.on('outgoing-message', listener);
 
-        messaging.getFeed('feed1')._sendMessage('user2', {
+        messaging.getFeed('mock:feed1')._sendMessage('user2', {
             type: 'app',
             json: {
                 v: 3,
@@ -553,9 +555,8 @@ async function testHandleInstallOkGet(engine) {
 module.exports = async function testRemote(engine) {
     const messaging = engine.messaging;
     //const remote = engine.remote;
-
-    assert.deepStrictEqual(messaging.type, 'mock');
-    assert.deepStrictEqual(messaging.account, 'user1');
+    assert(messaging.isAvailable);
+    assert(messaging.isSelf('mock-account:user1'));
 
     await testInstallProgram(engine);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,12 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.1.6":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.0.tgz#eaf3821fa0301d9d4aef88e63d4bcc19b73ba16c"
-  integrity sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==
+"@babel/generator@^7.0.0", "@babel/generator@^7.2.2":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.0.tgz#f663838cd7b542366de3aa608a657b8ccb2a99eb"
+  integrity sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==
   dependencies:
-    "@babel/types" "^7.2.0"
+    "@babel/types" "^7.3.0"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -52,39 +52,39 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
-  integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
+"@babel/parser@^7.0.0", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.1.tgz#8f4ffd45f779e6132780835ffa7a215fa0b2d181"
+  integrity sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
-  integrity sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
+  integrity sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.1.2"
-    "@babel/types" "^7.1.2"
+    "@babel/parser" "^7.2.2"
+    "@babel/types" "^7.2.2"
 
 "@babel/traverse@^7.0.0":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.6.tgz#c8db9963ab4ce5b894222435482bd8ea854b7b5c"
-  integrity sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
+  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.1.6"
+    "@babel/generator" "^7.2.2"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.1.6"
-    "@babel/types" "^7.1.6"
+    "@babel/parser" "^7.2.3"
+    "@babel/types" "^7.2.2"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
-  integrity sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
+"@babel/types@^7.0.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.0.tgz#61dc0b336a93badc02bf5f69c4cd8e1353f2ffc0"
+  integrity sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -101,9 +101,9 @@ acorn-jsx@^5.0.0:
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
 acorn@^6.0.2:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.4.tgz#77377e7353b72ec5104550aa2d2097a2fd40b754"
-  integrity sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.6.tgz#cd75181670d5b99bdb1b1c993941d3a239ab1f56"
+  integrity sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==
 
 addressparser@^1.0.1:
   version "1.0.1"
@@ -116,9 +116,9 @@ adt@^0.7.2, adt@~0.7.2:
   integrity sha1-gku3Jf42MsjDXsJJhd9hD5fZgkQ=
 
 ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
-  integrity sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.7.0.tgz#e3ce7bb372d6577bb1839f1dfdfcbf5ad2948d96"
+  integrity sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -130,10 +130,10 @@ another-json@^0.2.0:
   resolved "https://registry.yarnpkg.com/another-json/-/another-json-0.2.0.tgz#b5f4019c973b6dd5c6506a2d93469cb6d32aeedc"
   integrity sha1-tfQBnJc7bdXGUGotk0acttMq7tw=
 
-ansi-escapes@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-  integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -301,17 +301,10 @@ caching-transform@^2.0.0:
     package-hash "^2.0.0"
     write-file-atomic "^2.0.0"
 
-caller-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
-  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
-  dependencies:
-    callsites "^0.2.0"
-
-callsites@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
-  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
+callsites@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
+  integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
 
 camelcase@^4.1.0:
   version "4.1.0"
@@ -323,10 +316,10 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -430,9 +423,9 @@ convert-source-map@^1.6.0:
     safe-buffer "~5.1.1"
 
 core-js@^2.4.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
-  integrity sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.3.tgz#4b70938bdffdaf64931e66e2db158f0892289c49"
+  integrity sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -506,9 +499,9 @@ debug@^3.1.0:
     ms "^2.1.1"
 
 debug@^4.0.1, debug@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
-  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -605,9 +598,9 @@ eslint-visitor-keys@^1.0.0:
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
 eslint@^5.3.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.10.0.tgz#24adcbe92bf5eb1fc2d2f2b1eebe0c5e0713903a"
-  integrity sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.13.0.tgz#ce71cc529c450eed9504530939aa97527861ede9"
+  integrity sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.5.3"
@@ -626,6 +619,7 @@ eslint@^5.3.0:
     glob "^7.1.2"
     globals "^11.7.0"
     ignore "^4.0.6"
+    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.1.0"
     js-yaml "^3.12.0"
@@ -637,10 +631,8 @@ eslint@^5.3.0:
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
     progress "^2.0.0"
     regexpp "^2.0.1"
-    require-uncached "^1.0.3"
     semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
@@ -703,7 +695,7 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.0:
+external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
   integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
@@ -870,7 +862,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.2, glob@^7.1.3:
+glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -883,9 +875,9 @@ glob@^7.0.5, glob@^7.1.2, glob@^7.1.3:
     path-is-absolute "^1.0.0"
 
 globals@^11.1.0, globals@^11.7.0:
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249"
-  integrity sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
+  integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.15"
@@ -973,6 +965,14 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -997,20 +997,20 @@ ini@~1.3.0:
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inquirer@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
-  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
+  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^3.0.0"
+    external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rxjs "^6.1.0"
+    rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
     through "^2.3.6"
@@ -1137,9 +1137,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.11.0, js-yaml@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1385,9 +1385,9 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
     minimist "0.0.8"
 
 mri@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
-  integrity sha1-haom09ru7t+A3FmEr5XMXKXK2fE=
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
+  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
 
 ms@2.0.0:
   version "2.0.0"
@@ -1435,10 +1435,10 @@ node-gettext@^2.0.0:
   dependencies:
     lodash.get "^4.4.2"
 
-node-pre-gyp@^0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
-  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+node-pre-gyp@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
+  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -1468,9 +1468,9 @@ nopt@^4.0.1:
     osenv "^0.1.4"
 
 normalize-package-data@^2.3.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
-  integrity sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.2.tgz#6b2abd85774e51f7936f1395e45acb905dc849b2"
+  integrity sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -1483,9 +1483,9 @@ npm-bundled@^1.0.1:
   integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
 
 npm-packlist@^1.1.6:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
-  integrity sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.2.0.tgz#55a60e793e272f00862c7089274439a4cc31fc7f"
+  integrity sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -1636,9 +1636,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
-  integrity sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.1.0.tgz#1d5a0d20fb12707c758a655f6bbc4386b5930d68"
+  integrity sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==
   dependencies:
     p-try "^2.0.0"
 
@@ -1675,6 +1675,13 @@ package-hash@^2.0.0:
     lodash.flattendeep "^4.4.0"
     md5-hex "^2.0.0"
     release-zalgo "^1.0.0"
+
+parent-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  integrity sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -1728,11 +1735,6 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pluralize@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
-  integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -1754,9 +1756,9 @@ pseudomap@^1.0.2:
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
-  version "1.1.29"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
-  integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -1876,19 +1878,6 @@ require-relative@^0.8.7:
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
-require-uncached@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
-  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
-  dependencies:
-    caller-path "^0.1.0"
-    resolve-from "^1.0.0"
-
-resolve-from@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -1903,11 +1892,11 @@ restore-cursor@^2.0.0:
     signal-exit "^3.0.2"
 
 rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
-    glob "^7.0.5"
+    glob "^7.1.3"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -1916,10 +1905,10 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rxjs@^6.1.0:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
-  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+rxjs@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 
@@ -1965,10 +1954,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-slice-ansi@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.0.0.tgz#5373bdb8559b45676e8541c66916cdd6251612e7"
-  integrity sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==
+slice-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
   dependencies:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
@@ -2025,9 +2014,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
-  integrity sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
+  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2035,18 +2024,18 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sqlite3@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.4.tgz#1f75e3ededad6e26f7dd819929460ce44a49dfcd"
-  integrity sha512-CO8vZMyUXBPC+E3iXOCc7Tz2pAdq5BWfLcQmOokCOZW5S5sZ/paijiPOCdvzpdP83RroWHYa5xYlVqCxSqpnQg==
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.6.tgz#e587b583b5acc6cb38d4437dedb2572359c080ad"
+  integrity sha512-EqBXxHdKiwvNMRCgml86VTL5TK1i0IKiumnfxykX0gh6H6jaKijAXvE9O1N7+omfNSawR2fOmIyJZcfe8HYWpw==
   dependencies:
     nan "~2.10.0"
-    node-pre-gyp "^0.10.3"
+    node-pre-gyp "^0.11.0"
     request "^2.87.0"
 
 sshpk@^1.7.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.2.tgz#c946d6bd9b1a39d0e8635763f5242d6ed6dcb629"
-  integrity sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -2126,13 +2115,13 @@ supports-color@^5.3.0, supports-color@^5.4.0:
     has-flag "^3.0.0"
 
 table@^5.0.2:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.1.tgz#92030192f1b7b51b6eeab23ed416862e47b70837"
-  integrity sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.2.tgz#61d474c9e4d8f4f7062c98c7504acb3c08aa738f"
+  integrity sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==
   dependencies:
     ajv "^6.6.1"
     lodash "^4.17.11"
-    slice-ansi "2.0.0"
+    slice-ansi "^2.0.0"
     string-width "^2.1.1"
 
 tar@^4:
@@ -2180,9 +2169,9 @@ thingpedia-discovery@^1.0.0:
     node-ssdp "^2.7.2"
 
 thingpedia@^2.2.1, thingpedia@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/thingpedia/-/thingpedia-2.3.2.tgz#7029a12fee60079622b23ba9d5f82a4ab9605c25"
-  integrity sha512-ldxHUU+Wv3Q0THhxmIWA9DH4aEyfmHjboouTYWfGKaVRAtDJp3KGPCy/71qXVUTaD9QcnHXIKB20tY4wQ7XvSw==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/thingpedia/-/thingpedia-2.3.3.tgz#075dce993fa34d68699bd6eb525b41d657055d24"
+  integrity sha512-m/ee/iT/1WgnU75eRlUUeR/qT6QFY4XpCxQJuiCdNtGNb9VXdTBsEppcscOnDV3Ou/NQEJwiWLevOhwSZqprAA==
   dependencies:
     feedparser "^2.2.9"
     ip "~1.1.0"
@@ -2193,9 +2182,9 @@ thingpedia@^2.2.1, thingpedia@^2.3.0:
     xml2js "^0.4.17"
 
 thingtalk@^1.4.1, thingtalk@~1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.4.1.tgz#795a997dcd4d64a6431c1bd771a7c7676455f877"
-  integrity sha512-mrk4l/OHjI3TQeK362/oiikkvsoTBBLNaUxQnY2k8/XhuvaQQ0DTXQRGDOUi+yBE9Oom5RRnPgaghYuRr5UDWA==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.4.2.tgz#deab7fb65ccc06c53f978c84f2689bfe646edfde"
+  integrity sha512-xtNx8sOdit1oMr5Ej4RxcwAq1fdG/CxRlmh8/WMl9CI1nF9WDFD6/Jg17zkhORp4xoq61mnfOLmdMR4T5rdXAw==
   dependencies:
     adt "~0.7.2"
     byline "^5.0.0"
@@ -2341,9 +2330,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
-  integrity sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -2357,9 +2346,9 @@ write@^0.2.1:
     mkdirp "^0.5.1"
 
 ws@^6.0.0:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
-  integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.3.tgz#d2d2e5f0e3c700ef2de89080ebc0ac6e1bf3a72d"
+  integrity sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Very soon almond-cloud will grow a simple communication layer
to allow users on the same server to communicate without setting
up a matrix account.

At the same time, we don't want to lock users in to a more limited
messaging platform if they have already configured matrix, and we
don't want matrix to conflict with the platform messaging.

So instead we create a virtual platform, that is the union of
all configured messaging account. This means that a user can
use matrix, omlet or the almond builtin one freely, and will then
communicate using the appropriate account.

When resolving an identity (email/phone), we use the first messaging
interface that recognizes the identity (with priority to the platform
one).

Includes tests, that finally actually test matrix in some form
(and could make us marginally more confident to upgrade matrix-js-sdk
to a more recent version)