### PR TITLE
Engine: assert the existance of smt-solver if permissions are enabled

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -12,6 +12,8 @@
 // adds String.prototype.format(), for compat with existing Thingpedia code
 require('./polyfill');
 
+const assert = require('assert');
+
 const ThingTalk = require('thingtalk');
 const TpClient = require('thingpedia-client');
 
@@ -108,6 +110,7 @@ module.exports = class Engine {
         }
         if (hasPermissions) {
             const PermissionManager = require('./permissions/permission_manager');
+            assert(platform.hasCapability('smt-solver'));
 
             let groupDelegate;
             if (platform.hasCapability('permission-groups'))


### PR DESCRIPTION
It's a required capability.

This commit is mostly because at some point we had at least one
platform (iirc, almond-cloud) with enabled permissions but with
no smt solver available. With this, we would fail loudly enough
to catch the problem when bootstrapping the platform.

Fixes #29