### PR TITLE
Fix spurious parameter to BluetoothDevice

### DIFF
--- a/lib/devices/builtins/bluetooth.generic.js
+++ b/lib/devices/builtins/bluetooth.generic.js
@@ -20,7 +20,7 @@ module.exports = class BluetoothGenericDevice extends Tp.BaseDevice {
                                             uuids: publicData.uuids,
                                             class: publicData.class,
                                             hwAddress: privateData.address,
-                                            alias: privateData.alias }, true);
+                                            alias: privateData.alias });
     }
 
     constructor(engine, state) {


### PR DESCRIPTION
Copy-pasted from similar invocations of loadOneDevice (which require
the parameter).

Caught by lgtm.com